### PR TITLE
chore(env): change comment char

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-// Server
+# Server
 DATABASE_URL=***
 
 BETTER_AUTH_URL=http://localhost:3000
@@ -25,5 +25,5 @@ S3_SECRET_ACCESS_KEY=***
 S3_REGION=***
 R2_ACCOUNT_ID=***
 
-// Public
+# Public
 NEXT_PUBLIC_APP_URL=http://localhost:3000


### PR DESCRIPTION
## Problem
When copying the `.env.example`, the `//` for the comments raise errors on build of docker.

## Solve
Replace `//` with `#`